### PR TITLE
Update php-cs-fixer.config.php

### DIFF
--- a/php-cs-fixer.config.php
+++ b/php-cs-fixer.config.php
@@ -1,65 +1,64 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->notPath('.ebextensions')
-    ->notPath('.elasticbeanstalk')
-    ->notPath('docs')
-    ->notPath('public')
-    ->notPath('resources')
-    ->notPath('storage')
-    ->in(__DIR__)
-    ->name('*.php')
-    ->notName('*.blade.php')
-    ->ignoreDotFiles(true)
-    ->ignoreVCS(true);
+	->notPath('.ebextensions')
+	->notPath('.elasticbeanstalk')
+	->notPath('docs')
+	->notPath('public')
+	->notPath('resources')
+	->notPath('storage')
+	->in(__DIR__)
+	->name('*.php')
+	->notName('*.blade.php')
+	->ignoreDotFiles(true)
+	->ignoreVCS(true);
 
 $config = new PhpCsFixer\Config();
 
 return $config
-    ->setCacheFile(__DIR__ . '/vendor/.php_cs.cache')
-    ->setRules([
-        '@PSR12'          => true,
-        '@PHP80Migration' => true,
-        'binary_operator_spaces' => [
-            'operators' => [
-                '=>' => 'align_single_space_minimal'
-            ]
-        ],
-        'cast_spaces'                                 => ['space' => 'single'],
-        'ordered_imports'                             => ['sort_algorithm' => 'alpha'],
-        'no_unused_imports'                           => true,
-        'no_superfluous_phpdoc_tags'                  => ['allow_mixed' => true],
-        'blank_line_before_statement'                 => true,
-        'no_blank_lines_after_class_opening'          => true,
-        'no_blank_lines_after_phpdoc'                 => true,
-        'no_closing_tag'                              => true,
-        'no_empty_phpdoc'                             => true,
-        'no_leading_import_slash'                     => true,
-        'no_leading_namespace_whitespace'             => true,
-        'no_multiline_whitespace_around_double_arrow' => true,
-        'no_short_bool_cast'                          => true,
-        'no_singleline_whitespace_before_semicolons'  => true,
-        'no_spaces_after_function_name'               => true,
-        'no_spaces_inside_parenthesis'                => true,
-        'no_trailing_comma_in_list_call'              => true,
-        'no_trailing_comma_in_singleline_array'       => true,
-        'no_trailing_whitespace'                      => true,
-        'no_trailing_whitespace_in_comment'           => true,
-        'no_unused_imports'                           => true,
-        'no_useless_return'                           => true,
-        'no_whitespace_before_comma_in_array'         => true,
-        'no_empty_phpdoc'                             => true,
-        'phpdoc_align'                                => true,
-        'phpdoc_indent'                               => true,
-        'phpdoc_no_access'                            => true,
-        'phpdoc_no_package'                           => true,
-        'phpdoc_order'                                => true,
-        'phpdoc_scalar'                               => true,
-        'phpdoc_separation'                           => true,
-        'phpdoc_summary'                              => true,
-        'phpdoc_to_comment'                           => true,
-        'phpdoc_trim'                                 => true,
-        'phpdoc_types'                                => true,
-        'phpdoc_var_without_name'                     => true,
-    ])
-    ->setFinder($finder);
+	->setCacheFile(__DIR__ . '/vendor/.php_cs.cache')
+	->setRules([
+		'@PSR12'          => true,
+		'@PHP80Migration' => true,
+		'binary_operator_spaces' => [
+			'operators' => [
+				'=>' => 'align_single_space_minimal'
+			]
+		],
+		'blank_line_before_statement'                 => true,
+		'cast_spaces'                                 => ['space' => 'single'],
+		'no_blank_lines_after_class_opening'          => true,
+		'no_blank_lines_after_phpdoc'                 => true,
+		'no_closing_tag'                              => true,
+		'no_empty_phpdoc'                             => true,
+		'no_leading_import_slash'                     => true,
+		'no_leading_namespace_whitespace'             => true,
+		'no_multiline_whitespace_around_double_arrow' => true,
+		'no_short_bool_cast'                          => true,
+		'no_singleline_whitespace_before_semicolons'  => true,
+		'no_spaces_after_function_name'               => true,
+		'no_spaces_inside_parenthesis'                => true,
+		'no_superfluous_phpdoc_tags'                  => ['allow_mixed' => true],
+		'no_trailing_comma_in_list_call'              => true,
+		'no_trailing_comma_in_singleline_array'       => true,
+		'no_trailing_whitespace'                      => true,
+		'no_trailing_whitespace_in_comment'           => true,
+		'no_unused_imports'                           => true,
+		'no_useless_return'                           => true,
+		'no_whitespace_before_comma_in_array'         => true,
+		'ordered_imports'                             => ['sort_algorithm' => 'alpha'],
+		'phpdoc_align'                                => true,
+		'phpdoc_indent'                               => true,
+		'phpdoc_line_span'                            => ['method' => 'single', 'const' => 'single', 'property' => 'single'],
+		'phpdoc_no_access'                            => true,
+		'phpdoc_no_package'                           => true,
+		'phpdoc_order'                                => true,
+		'phpdoc_scalar'                               => true,
+		'phpdoc_separation'                           => true,
+		'phpdoc_summary'                              => true,
+		'phpdoc_to_comment'                           => true,
+		'phpdoc_trim'                                 => true,
+		'phpdoc_types'                                => true,
+		'phpdoc_var_without_name'                     => true,
+	])
+	->setFinder($finder);


### PR DESCRIPTION
# Description

- Sorted
- Removed duplicates
- Added the following rule:	
`'phpdoc_line_span'                            => ['method' => 'single', 'const' => 'single', 'property' => 'single'],`

https://git.orion.in.net/wok/telstra-alarm-multi/-/blob/326ea9ba9f7e638226e14e446624bf70efe8a059/vendor/friendsofphp/php-cs-fixer/src/Fixer/Phpdoc/PhpdocLineSpanFixer.php

> Changes doc blocks from single to multi line, or reversed. Works for class constants, properties and methods only.

Example:
![image](https://user-images.githubusercontent.com/36499489/126317821-f9c271b1-9548-4cc7-8d40-0837fddf6e02.png)

## Multiline stays multiline

@ElwinAtabix 
Regarding multiline docs, they remain the same:

These docblocks remain the same:
![image](https://user-images.githubusercontent.com/36499489/126318006-1a5bef72-5b5c-4cd5-b3e0-8b8362ed520a.png)

