### PR TITLE
not_operator_with_successor_space = true

### DIFF
--- a/php-cs-fixer.config.php
+++ b/php-cs-fixer.config.php
@@ -46,6 +46,7 @@ return $config
 		'no_unused_imports'                           => true,
 		'no_useless_return'                           => true,
 		'no_whitespace_before_comma_in_array'         => true,
+		'not_operator_with_successor_space'           => true,
 		'ordered_imports'                             => ['sort_algorithm' => 'alpha'],
 		'phpdoc_align'                                => true,
 		'phpdoc_indent'                               => true,


### PR DESCRIPTION
Logical NOT operators (!) should have one trailing whitespace.
See https://cs.symfony.com/doc/rules/operator/not_operator_with_successor_space.html

Until recently, php-cs-fixer left any space-or-not after the NOT-operator "as is", but now it actively removes all space.

This PR sets the `not_operator_with_successor_space` rule explicitly to true.
