### PR TITLE
Download new version using SSL, and prevent empty file

### DIFF
--- a/php-cs-fixer.dist.php
+++ b/php-cs-fixer.dist.php
@@ -8,22 +8,36 @@ if (Cache::expired(CONFIG_FILE, CACHE_MINUTES_TTL)) {
     Cache::download(CONFIG_URL, CONFIG_FILE);
 }
 
+if (! class_exists(PhpCsFixer\Finder::class)) {
+    return null;
+}
+
 return require CONFIG_FILE;
 
 class Cache
 {
     public static function expired($file, $minutes = 5)
     {
-        $isValid = \file_exists(rtrim(__DIR__, '/') . '/'. $file) && (\filemtime(rtrim(__DIR__, '/') . '/'. $file) > (\time() - 60 * $minutes));
+        $isValid = file_exists(rtrim(__DIR__, '/') . '/'. $file) && (filemtime(rtrim(__DIR__, '/') . '/'. $file) > (time() - 60 * $minutes));
 
         return ! $isValid;
     }
 
     public static function download($url, $file)
     {
-        $contents = \file_get_contents($url);
+        $context = [
+            'ssl' => [
+                'verify_peer'      => false,
+                'verify_peer_name' => false,
+            ],
+        ];
+        $contents = file_get_contents($url, false, stream_context_create($context));
 
-        \file_put_contents(rtrim(__DIR__, '/') .'/'. $file, $contents, LOCK_EX);
+        if (strlen($contents) < 100) {
+            throw new Exception('Empty source');
+        }
+
+        file_put_contents(rtrim(__DIR__, '/') .'/'. $file, $contents, LOCK_EX);
 
         return 0;
     }


### PR DESCRIPTION
Credits to @atabixalex for his Teams message of 17-10-2023, instructing these changes.

Downloading from Github via HTTPS now requires a correct SSL-stream config in PHP.
This PR implements that.

Furthermore, a few failsafe rules are added, to prevent to end up with an empty config file when the download fails.


