### PR TITLE
rule: imports_order

### DIFF
--- a/php-cs-fixer.config.php
+++ b/php-cs-fixer.config.php
@@ -17,7 +17,7 @@ $config = new PhpCsFixer\Config();
 
 return $config
     ->setCacheFile(__DIR__ . '/vendor/.php_cs.cache')
-  	->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@PER-CS'                => true,
         '@PHP84Migration'        => true,
@@ -48,7 +48,7 @@ return $config
         'no_useless_return'                           => true,
         'no_whitespace_before_comma_in_array'         => true,
         'not_operator_with_successor_space'           => true,
-        'ordered_imports'                             => ['sort_algorithm' => 'alpha'],
+        'ordered_imports'                             => ['sort_algorithm' => 'alpha', 'imports_order' => ['const', 'class', 'function']],
         'phpdoc_align'                                => true,
         'phpdoc_indent'                               => true,
         'phpdoc_line_span'                            => ['method' => 'single', 'const' => 'single', 'property' => 'single'],


### PR DESCRIPTION
Default behaviour is to mix classes and functions, adding whitelines between every switch of types. This rule will group imported classes and functions apart.

BEFORE:
```php
use App\Models\User;
use Closure;
use Exception;
use Illuminate\Support\Arr;
use RuntimeException;

use function Sentry\addBreadcrumb;

use Sentry\Breadcrumb;

use function Sentry\captureException;

use Sentry\Event;
use Sentry\ExceptionDataBag;
use Sentry\Laravel\Integration as LaravelIntegration;
use Sentry\SentrySdk;
use Sentry\Severity;
use Sentry\State\HubInterface;
use Sentry\State\Scope;

use function Sentry\withScope;

use Throwable;
```

AFTER:
```php
use App\Models\User;
use Closure;
use Exception;
use Illuminate\Support\Arr;
use RuntimeException;
use Sentry\Breadcrumb;
use Sentry\Event;
use Sentry\ExceptionDataBag;
use Sentry\Laravel\Integration as LaravelIntegration;
use Sentry\SentrySdk;
use Sentry\Severity;
use Sentry\State\HubInterface;
use Sentry\State\Scope;
use Throwable;

use function Sentry\addBreadcrumb;
use function Sentry\captureException;
use function Sentry\withScope;
```