### PR TITLE
Always use parentheses arouund new classes

### DIFF
--- a/php-cs-fixer.config.php
+++ b/php-cs-fixer.config.php
@@ -63,5 +63,6 @@ return $config
         'phpdoc_types'                                => true,
         'phpdoc_var_without_name'                     => true,
         'types_spaces'                                => ['space' => 'none'],
+        'new_expression_parentheses'                  => ['use_parentheses' => true],
     ])
     ->setFinder($finder);


### PR DESCRIPTION
Added explicit rule for new_expression_parentheses to keep parentheses when chaining on a new instance.

Without this override, PHP-CS-Fixer (with @PHP84Migration) was rewriting:
`(new AzureUploadService())->uploadCsv()` to `new AzureUploadService()->uploadCsv(...)`

This change ensures the original style is preserved and avoids unnecessary diffs.
